### PR TITLE
v1.11.2

### DIFF
--- a/.spyglassrc.json
+++ b/.spyglassrc.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "gameVersion": "1.21.9",
+    "gameVersion": "1.21.10",
     "exclude": []
   }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,2 @@
-- **Added support for Minecraft 1.21.9** 🥉
-  - Updated to work with the new pack.mcmeta syntax
-- Raised entity processing limits to resolve mob farm complications (Thanks @Fyoncle)
-- Fixed Vanilla activation mode behaving the same way as Classic for activation distances below 25 (closes [#46](https://github.com/Tschipcraft/spawnanimations/issues/46))
-- Added native support for snow blocks when playing the dig up animation
-- Removed native support for some container blocks
-- Expanded and reorganized tag lists to include convention tags for improved mod compatibility
+- **Added support for Minecraft 1.21.10** 🧩
+- Fixed dig up animation particles no longer appearing in Minecraft 1.20.6 and below

--- a/data/spawnanimations/function/internal/version_checker/start.mcfunction
+++ b/data/spawnanimations/function/internal/version_checker/start.mcfunction
@@ -1,7 +1,7 @@
 ##by Tschipcraft
 
 execute store result score $version ts.sa.settings run data get entity @r DataVersion
-execute unless score $global tvc_ignore matches 1 if score $version ts.sa.settings matches 4600.. run tellraw @a [{"text":"[Spawn Animations] ","color":"gray"},{"text":"?","bold":true,"color":"gold"},{"text":" Future unknown Minecraft version above 1.21.9 detected! This data pack/mod may not work correctly anymore! Please make sure to check for updates in the menu! (","color":"gold"},{"text":"/trigger tschipcraft.menu","underlined":true,"color":"gold","click_event":{"action":"run_command","command":"trigger tschipcraft.menu"},"hover_event":{"action":"show_text","value":"Click here","text":"Click here"}},{"text":")","color":"gold"}]
+execute unless score $global tvc_ignore matches 1 if score $version ts.sa.settings matches 4600.. run tellraw @a [{"text":"[Spawn Animations] ","color":"gray"},{"text":"?","bold":true,"color":"gold"},{"text":" Future unknown Minecraft version above 1.21.10 detected! This data pack/mod may not work correctly anymore! Please make sure to check for updates in the menu! (","color":"gold"},{"text":"/trigger tschipcraft.menu","underlined":true,"color":"gold","click_event":{"action":"run_command","command":"trigger tschipcraft.menu"},"hover_event":{"action":"show_text","value":"Click here","text":"Click here"}},{"text":")","color":"gold"}]
 # Note: 1.17x-1.20x uses the old folder names (function -> functions)
 
 # Announce escape sequence handling changes

--- a/data/spawnanimations/functions/internal/animation/dig_up/particles/particles.mcfunction
+++ b/data/spawnanimations/functions/internal/animation/dig_up/particles/particles.mcfunction
@@ -20,7 +20,7 @@ execute if block ~ ~ ~ minecraft:cobblestone run particle minecraft:block minecr
 execute if block ~ ~ ~ minecraft:hay_block run particle minecraft:block minecraft:hay_block ~ ~0.2 ~ 0.1 0 0.1 1 9 normal
 execute if block ~ ~ ~ minecraft:gravel run particle minecraft:block minecraft:gravel ~ ~0.2 ~ 0.1 0 0.1 1 9 normal
 execute if block ~ ~0.3 ~ minecraft:snow run particle minecraft:block minecraft:snow ~ ~0.4 ~ 0.1 0 0.1 1 9 normal
-execute if block ~ ~ ~ minecraft:snow_block unless block ~ ~0.3 ~ minecraft:snow run particle minecraft:block minecraft:snow_block ~0.2 ~ 0.1 0 0.1 1 9 normal
+execute if block ~ ~ ~ minecraft:snow_block unless block ~ ~0.3 ~ minecraft:snow run particle minecraft:block minecraft:snow_block ~ ~0.2 ~ 0.1 0 0.1 1 9 normal
 execute if block ~ ~ ~ #minecraft:ice run particle minecraft:block minecraft:ice ~ ~0.2 ~ 0.1 0 0.1 1 9 normal
 execute if block ~ ~ ~ minecraft:obsidian run particle minecraft:block minecraft:obsidian ~ ~0.2 ~ 0.1 0 0.1 1 9 normal
 execute if block ~ ~ ~ minecraft:slime_block run particle minecraft:block minecraft:slime_block ~ ~0.2 ~ 0.1 0 0.1 1 9 normal


### PR DESCRIPTION
- **Added support for Minecraft 1.21.10** 🧩
- Fixed dig up animation particles no longer appearing in Minecraft 1.20.6 and below