### PR TITLE
v1.11.3

### DIFF
--- a/.spyglassrc.json
+++ b/.spyglassrc.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "gameVersion": "1.21.10",
+    "gameVersion": "1.21.11",
     "exclude": []
   }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,4 @@
-- **Added support for Minecraft 1.21.10** 🧩
-- Fixed dig up animation particles no longer appearing in Minecraft 1.20.6 and below
+- **Added support for Minecraft 1.21.11** 🐎
+  - Updated to work with the new gamerule names
+  - Removed broken hide feedback code for 1.21+
+  - Bumped pack format and protocol version

--- a/data/spawnanimations/function/internal/animation/dig_up/sound/support.mcfunction
+++ b/data/spawnanimations/function/internal/animation/dig_up/sound/support.mcfunction
@@ -1,8 +1,7 @@
 ##by Tschipcraft
 
 # Preserve gamerule
-execute store result score $gamerule.tile_drops ts.sa.settings run gamerule doTileDrops
-execute if score $gamerule.tile_drops ts.sa.settings matches 1 run gamerule doTileDrops false
+function spawnanimations:internal/animation/dig_up/sound/tile_drops/disable
 
 # Preserve bedrock/air
 scoreboard players set $block ts.sa.settings 0
@@ -47,4 +46,4 @@ execute if score $play_unsupport ts.sa.settings matches 1..2 if score $block ts.
 execute unless score $block ts.sa.settings matches 0 run kill @e[type=minecraft:item,nbt={Age:0s},distance=..2]
 
 # Preserve gamerule
-execute if score $gamerule.tile_drops ts.sa.settings matches 1 run gamerule doTileDrops true
+function spawnanimations:internal/animation/dig_up/sound/tile_drops/enable

--- a/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/disable.mcfunction
+++ b/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/disable.mcfunction
@@ -1,0 +1,5 @@
+##by Tschipcraft
+# Temporarily disables tile drops to execute block break without drops
+
+execute store result score $gamerule.tile_drops ts.sa.settings run gamerule block_drops
+execute if score $gamerule.tile_drops ts.sa.settings matches 1 run gamerule block_drops false

--- a/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/enable.mcfunction
+++ b/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/enable.mcfunction
@@ -1,0 +1,4 @@
+##by Tschipcraft
+# Re-enables tile drops if previously disabled
+
+execute if score $gamerule.tile_drops ts.sa.settings matches 1 run gamerule block_drops true

--- a/data/spawnanimations/function/internal/version_checker/start.mcfunction
+++ b/data/spawnanimations/function/internal/version_checker/start.mcfunction
@@ -1,7 +1,7 @@
 ##by Tschipcraft
 
 execute store result score $version ts.sa.settings run data get entity @r DataVersion
-execute unless score $global tvc_ignore matches 1 if score $version ts.sa.settings matches 4600.. run tellraw @a [{"text":"[Spawn Animations] ","color":"gray"},{"text":"?","bold":true,"color":"gold"},{"text":" Future unknown Minecraft version above 1.21.10 detected! This data pack/mod may not work correctly anymore! Please make sure to check for updates in the menu! (","color":"gold"},{"text":"/trigger tschipcraft.menu","underlined":true,"color":"gold","click_event":{"action":"run_command","command":"trigger tschipcraft.menu"},"hover_event":{"action":"show_text","value":"Click here","text":"Click here"}},{"text":")","color":"gold"}]
+execute unless score $global tvc_ignore matches 1 if score $version ts.sa.settings matches 4700.. run tellraw @a [{"text":"[Spawn Animations] ","color":"gray"},{"text":"?","bold":true,"color":"gold"},{"text":" Future unknown Minecraft version above 1.21.11 detected! This data pack/mod may not work correctly anymore! Please make sure to check for updates in the menu! (","color":"gold"},{"text":"/trigger tschipcraft.menu","underlined":true,"color":"gold","click_event":{"action":"run_command","command":"trigger tschipcraft.menu"},"hover_event":{"action":"show_text","value":"Click here","text":"Click here"}},{"text":")","color":"gold"}]
 # Note: 1.17x-1.20x uses the old folder names (function -> functions)
 
 # Announce escape sequence handling changes

--- a/data/spawnanimations/function/settings/core.mcfunction
+++ b/data/spawnanimations/function/settings/core.mcfunction
@@ -43,5 +43,4 @@ execute if score $play_sounds ts.sa.settings matches 1..2 if score $play_unsuppo
 execute if score $play_sounds ts.sa.settings matches 1..2 if score $play_unsupport ts.sa.settings matches 2 run tellraw @s [{"text":"Play Animation on Unsupported Blocks   [>✔<]  |  [❌]","bold":false,"color":"gray","hover_event":{"action":"show_text","value":"This setting is getting controlled globally and can't be changed here."}}]
 execute if score $play_sounds ts.sa.settings matches -1..0 run tellraw @s [{"text":"Play Animation on Unsupported Blocks   [✔]  |  [>❌<]","bold":false,"color":"gray","hover_event":{"action":"show_text","value":[{"text":"Enable [Play Animation Sounds] first."}]}}]
 
-function spawnanimations:settings/hide_feedback/main
 playsound minecraft:block.dispenser.dispense master @s ~ ~ ~ 0.2 2

--- a/data/spawnanimations/function/settings/hide_feedback/hide.mcfunction
+++ b/data/spawnanimations/function/settings/hide_feedback/hide.mcfunction
@@ -1,4 +1,0 @@
-##by Tschipcraft
-
-gamerule sendCommandFeedback false
-schedule function spawnanimations:settings/hide_feedback/unhide 1t

--- a/data/spawnanimations/function/settings/hide_feedback/main.mcfunction
+++ b/data/spawnanimations/function/settings/hide_feedback/main.mcfunction
@@ -1,5 +1,0 @@
-##by Tschipcraft
-
-execute store result score $gamerule.send_feedback ts.sa.settings run gamerule sendCommandFeedback
-
-execute if score $gamerule.send_feedback ts.sa.settings matches 1 run function spawnanimations:settings/hide_feedback/hide

--- a/data/spawnanimations/function/settings/hide_feedback/unhide.mcfunction
+++ b/data/spawnanimations/function/settings/hide_feedback/unhide.mcfunction
@@ -1,3 +1,0 @@
-##by Tschipcraft
-
-gamerule sendCommandFeedback true

--- a/data/tschipcraft/function/menu_header.mcfunction
+++ b/data/tschipcraft/function/menu_header.mcfunction
@@ -1,4 +1,3 @@
 ##by Tschipcraft
 
 tellraw @s {"text":"The following packs are installed:","color":"gold"}
-function spawnanimations:settings/hide_feedback/main

--- a/overlay_pre_63/data/spawnanimations/function/settings/core.mcfunction
+++ b/overlay_pre_63/data/spawnanimations/function/settings/core.mcfunction
@@ -43,5 +43,4 @@ execute if score $play_sounds ts.sa.settings matches 1..2 if score $play_unsuppo
 execute if score $play_sounds ts.sa.settings matches 1..2 if score $play_unsupport ts.sa.settings matches 2 run tellraw @s [{"text":"Play Animation on Unsupported Blocks   [>✔<]  |  [❌]","bold":false,"color":"gray","hoverEvent":{"action":"show_text","contents":[{"text":"This setting is getting controlled globally and can't be changed here."}]}}]
 execute if score $play_sounds ts.sa.settings matches -1..0 run tellraw @s [{"text":"Play Animation on Unsupported Blocks   [✔]  |  [>❌<]","bold":false,"color":"gray","hoverEvent":{"action":"show_text","contents":[{"text":"Enable [Play Animation Sounds] first."}]}}]
 
-function spawnanimations:settings/hide_feedback/main
 playsound minecraft:block.dispenser.dispense master @s ~ ~ ~ 0.2 2

--- a/overlay_pre_92/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/disable.mcfunction
+++ b/overlay_pre_92/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/disable.mcfunction
@@ -1,0 +1,5 @@
+##by Tschipcraft
+# Temporarily disables tile drops to execute block break without drops
+
+execute store result score $gamerule.tile_drops ts.sa.settings run gamerule doTileDrops
+execute if score $gamerule.tile_drops ts.sa.settings matches 1 run gamerule doTileDrops false

--- a/overlay_pre_92/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/enable.mcfunction
+++ b/overlay_pre_92/data/spawnanimations/function/internal/animation/dig_up/sound/tile_drops/enable.mcfunction
@@ -1,0 +1,4 @@
+##by Tschipcraft
+# Re-enables tile drops if previously disabled
+
+execute if score $gamerule.tile_drops ts.sa.settings matches 1 run gamerule doTileDrops true

--- a/overlay_pre_92/overrides.impdoc
+++ b/overlay_pre_92/overrides.impdoc
@@ -1,0 +1,4 @@
+@targets 24w21a..25w43a
+@changes function calls
+ 
+- Old gamerule name `block_drops` -> `doTileDrops`

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -2,9 +2,9 @@
   "id": "spawnanimations",
   "pack": {
     "pack_format": 15,
-    "supported_formats": [7, 88],
+    "supported_formats": [7, 94],
     "min_format": 7,
-    "max_format": 88,
+    "max_format": 94,
     "description": "Tschipcraft's Spawn Animations\n└ v${version} ● mc${mc_human_version_range}"
   },
   "overlays": {
@@ -38,6 +38,12 @@
         "min_format": 45,
         "max_format": 62,
         "directory": "overlay_pre_63"
+      },
+      {
+        "formats": [45,91],
+        "min_format": 45,
+        "max_format": 91,
+        "directory": "overlay_pre_92"
       }
     ]
   }


### PR DESCRIPTION
- **Added support for Minecraft 1.21.11** 🐎
  - Updated to work with the new gamerule names (`doTileDrops` ⇾ `block_drops`)
  - Removed broken hide feedback code for 1.21+
  - Bumped pack format and protocol version